### PR TITLE
scons: manage qt4 and sndfile as optional dependencies + fix build on windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,26 +10,26 @@ cd loudness_validator
 
 ## Build
 
-#### Build all tools in release mode.
+#### Build all tools in release mode
 ```
 scons
 ```
 
-#### Build in debug mode.
+#### Build in debug mode
 ```
 scons mode=debug
 ```
 
-#### Build with a specific path to libraries.
+#### Build with a specific path to libraries
 ```
-scons BOOST_ROOT=/path/to/boost SNDFILE_ROOT=/path/to/sndfile
+scons BOOST_ROOT=/path/to/boost SNDFILE_ROOT=/path/to/sndfile QTDIR=/path/to/qt4
 ```
 
 
 ## Dependencies
 
 #### Libraries
-libloudnessAnalyser and loudnessTools require libsndfile and boost accumulators.
+__libloudnessAnalyser__ and __loudnessTools__ require __libsndfile__ and __boost accumulators__.
 
 #### Apps
 loudnessValidator requires also Qt4.

--- a/SConstruct
+++ b/SConstruct
@@ -94,6 +94,7 @@ elif env['CC'] == 'cl':  # msvc
 # Build src and app
 
 Export( 'env' )
+Export( 'loudnessAssessmentVersionStr' )
 
 VariantDir( 'build/' + buildMode + '/src', 'src', duplicate = 0 )
 VariantDir( 'build/' + buildMode + '/app', 'app', duplicate = 0 )

--- a/SConstruct
+++ b/SConstruct
@@ -80,7 +80,16 @@ if env['CC'] == 'gcc':
     if buildMode == 'release':
         env.Append( CXXFLAGS = ['-O3'] )
     else:
-        env.Append( CXXFLAGS=['-g'] )
+        env.Append( CXXFLAGS = ['-g'] )
+elif env['CC'] == 'cl':  # msvc
+    # Exception handling used by the compiler
+    env.Append( CXXFLAGS = ['/EHsc'] )
+    if buildMode == 'release':
+        # Use the multithread, static version of the run-time library
+        env.Append( CXXFLAGS = ['/MT'] )
+    else:
+        # Plus DEBUG option
+        env.Append( CXXFLAGS = ['/MTd'] )
 
 # Build src and app
 

--- a/SConstruct
+++ b/SConstruct
@@ -33,6 +33,9 @@ if boost_root:
     boost_include = boost_root + '/include'
     boost_lib = boost_root + '/lib'
 
+# Get qt4 install path
+qt4_dir = ARGUMENTS.get( 'QTDIR', '' )
+
 # Create env
 env = Environment()
 
@@ -41,7 +44,6 @@ env.Append(
                 '#src',
                 sndfile_include,
                 boost_include,
-		'/usr/include/qt4',
         ],
         CXXFLAGS = [
                 '-Wall',
@@ -58,12 +60,21 @@ env.Append(
         SHLIBVERSION = loudnessAssessmentVersionStr,
         )
 
+# Set QTDIR if specify
+if qt4_dir:
+    env.Append(
+        QTDIR = qt4_dir,
+    )
+
+# Set frameworks path if MacOS
 if env['PLATFORM'] == "darwin":
     env.Append(
         FRAMEWORKPATH = [
             '/usr/local/Frameworks',
         ],
     )
+
+# Add compile flags
 if buildMode == 'release':
     env.Append( CXXFLAGS=['-O3'] )
 else:

--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ if boost_root:
     boost_lib = boost_root + '/lib'
 
 # Get qt4 install path
-qt4_dir = ARGUMENTS.get( 'QTDIR', '' )
+qt4_dir = ARGUMENTS.get( 'QTDIR', '/usr/' )
 
 # Create env
 env = Environment()

--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,5 @@
+import os
+
 EnsureSConsVersion( 2, 3, 0 )
 
 # Versions
@@ -22,16 +24,16 @@ sndfile_root = ARGUMENTS.get( 'SNDFILE_ROOT', '' )
 sndfile_include = ''
 sndfile_lib = ''
 if sndfile_root:
-    sndfile_include = sndfile_root + '/include'
-    sndfile_lib = sndfile_root + '/lib'
+    sndfile_include = os.path.join( sndfile_root, 'include' )
+    sndfile_lib = os.path.join( sndfile_root, 'lib' )
 
 # Get libboost install path
 boost_root = ARGUMENTS.get( 'BOOST_ROOT', '' )
 boost_include = ''
 boost_lib = ''
 if boost_root:
-    boost_include = boost_root + '/include'
-    boost_lib = boost_root + '/lib'
+    boost_include = os.path.join( boost_root, 'include' )
+    boost_lib = os.path.join( boost_root, 'lib' )
 
 # Get qt4 install path
 qt4_dir = ARGUMENTS.get( 'QTDIR', '/usr/' )

--- a/SConstruct
+++ b/SConstruct
@@ -46,8 +46,6 @@ env.Append(
                 boost_include,
         ],
         CXXFLAGS = [
-                '-Wall',
-                '-fPIC',
                 '-DLOUDNESS_ASSESSMENT_VERSION_MAJOR=' + loudnessAssessmentVersionMajor,
                 '-DLOUDNESS_ASSESSMENT_VERSION_MINOR=' + loudnessAssessmentVersionMinor,
                 '-DLOUDNESS_ASSESSMENT_VERSION_MICRO=' + loudnessAssessmentVersionMicro,
@@ -75,10 +73,12 @@ if env['PLATFORM'] == "darwin":
     )
 
 # Add compile flags
-if buildMode == 'release':
-    env.Append( CXXFLAGS=['-O3'] )
-else:
-    env.Append( CXXFLAGS=['-g'] )
+if env['CC'] == 'gcc':
+    env.Append( CXXFLAGS = ['-Wall', '-fPIC'] )
+    if buildMode == 'release':
+        env.Append( CXXFLAGS = ['-O3'] )
+    else:
+        env.Append( CXXFLAGS=['-g'] )
 
 # Build src and app
 

--- a/app/LoudnessValidator/PLoudGui.cpp
+++ b/app/LoudnessValidator/PLoudGui.cpp
@@ -321,8 +321,8 @@ void analyseFiles( Loudness::io::SoundFile* audioFile, size_t channels, Loudness
 {
 	int cumulOfSamples = 0;
 	int bufferSize = audioFile[0].getSampleRate() / 5;
-	
-	float *data [ channels ];
+
+	float* data[ MAX_CHANNELS ];
 
 	for( size_t i = 0; i< channels; i++ )
 		data [i] = new float [bufferSize];

--- a/app/LoudnessValidator/PLoudProcess.cpp
+++ b/app/LoudnessValidator/PLoudProcess.cpp
@@ -1,5 +1,6 @@
 #include "PLoudProcess.hpp"
 #include <iostream>
+#include <algorithm>
 
 PLoudProcess::PLoudProcess( Loudness::LoudnessLevels levels, float frequencyForTruePeak )
 	: Loudness::LoudnessAnalyser( levels )
@@ -62,7 +63,7 @@ void PLoudProcess::processAnalyseFile( void (*callback)(void*, int), void* objec
 	
 	size_t channelsInBuffer = std::min( 5, audioFile->getNbChannels() );
 	int bufferSize = audioFile->getSampleRate() / 5;
-	float *data [ channelsInBuffer ];
+	float *data [ MAX_CHANNELS ];
 	float* inpb = new float [ audioFile->getNbChannels() * bufferSize ];
 	
 	for( size_t i = 0; i< channelsInBuffer; i++ )
@@ -190,8 +191,8 @@ void PLoudProcess::writeFile( void (*callback)(void*, int), void* object, double
 	int bufferSize = audioFiles.at(0)->getSampleRate() / 5;
 	size_t channelsInBuffer = std::min( 5, audioFiles.at(0)->getNbChannels() );
 	size_t cumulOfSamples = 0;
-	
-	float* data [ channelsInBuffer ];
+
+	float* data [ MAX_CHANNELS ];
 	float* inpb  = new float [audioFiles.at(0)->getNbChannels() * bufferSize];
 	
 	for( size_t i=0; i < channelsInBuffer; i++ )

--- a/app/SConscript
+++ b/app/SConscript
@@ -39,10 +39,17 @@ if 'loudnessToolsLibStatic' in locals():
 
 	### loudness-validator ###
 
+	# Get qt4 lib name
+	qt4CoreLib = 'QtCore'
+	qt4GuiLib = 'QtGui'
+	if env['PLATFORM'] == 'win32':
+		qt4CoreLib = qt4CoreLib + '4'
+		qt4GuiLib = qt4GuiLib + '4'
+
 	# check qt4 library
 	qtEnv = env.Clone()
 	conf = Configure(qtEnv)
-	if conf.CheckLib('QtCore', language='cxx'):
+	if conf.CheckLib(qt4CoreLib, language='cxx'):
 	    qtEnv = conf.Finish()
 
 	    qtEnv.Tool('qt')
@@ -56,8 +63,8 @@ if 'loudnessToolsLibStatic' in locals():
 	    loudnessValidatorFrameworks = []
 
 	    QtLibs = [
-	        'QtCore',
-	        'QtGui',
+	        qt4CoreLib,
+	        qt4GuiLib,
 	    ]
 
 	    if not qtEnv['PLATFORM'] == 'darwin':

--- a/app/SConscript
+++ b/app/SConscript
@@ -5,6 +5,11 @@ Import( '*' )
 
 if 'loudnessToolsLibStatic' in locals():
 
+	# Get sndfile lib name
+	sndfileLib = 'sndfile'
+	if env['PLATFORM'] == 'win32':
+	    sndfileLib = 'lib' + sndfileLib
+
 	### loudness-analyser ###
 
 	loudnessAnalyserProgram = env.Program(
@@ -13,7 +18,7 @@ if 'loudnessToolsLibStatic' in locals():
 		LIBS = [
 			loudnessAnalyserLibStatic,
 			loudnessToolsLibStatic,
-			'sndfile',
+			sndfileLib,
 		]
 	)
 
@@ -25,7 +30,7 @@ if 'loudnessToolsLibStatic' in locals():
 		LIBS = [
 			loudnessAnalyserLibStatic,
 			loudnessToolsLibStatic,
-			'sndfile',
+			sndfileLib,
 		]
 	)
 
@@ -45,7 +50,7 @@ if 'loudnessToolsLibStatic' in locals():
 	    loudnessValidatorLibraries = [
 	        loudnessAnalyserLibStatic,
 	        loudnessToolsLibStatic,
-	        'sndfile',
+	        sndfileLib,
 	    ]
 
 	    loudnessValidatorFrameworks = []

--- a/app/SConscript
+++ b/app/SConscript
@@ -13,7 +13,7 @@ if 'loudnessToolsLibStatic' in locals():
 		LIBS = [
 			loudnessAnalyserLibStatic,
 			loudnessToolsLibStatic,
-			"sndfile",
+			'sndfile',
 		]
 	)
 
@@ -25,7 +25,7 @@ if 'loudnessToolsLibStatic' in locals():
 		LIBS = [
 			loudnessAnalyserLibStatic,
 			loudnessToolsLibStatic,
-			"sndfile",
+			'sndfile',
 		]
 	)
 
@@ -45,17 +45,17 @@ if 'loudnessToolsLibStatic' in locals():
 	    loudnessValidatorLibraries = [
 	        loudnessAnalyserLibStatic,
 	        loudnessToolsLibStatic,
-	        "sndfile",
+	        'sndfile',
 	    ]
 
 	    loudnessValidatorFrameworks = []
 
 	    QtLibs = [
-	        "QtCore",
-	        "QtGui",
+	        'QtCore',
+	        'QtGui',
 	    ]
 
-	    if not qtEnv['PLATFORM'] == "darwin":
+	    if not qtEnv['PLATFORM'] == 'darwin':
 	        loudnessValidatorLibraries.append( QtLibs )
 	    else:
 	        loudnessValidatorFrameworks.append( QtLibs )

--- a/app/SConscript
+++ b/app/SConscript
@@ -24,34 +24,43 @@ loudnessCorrectorProgram = env.Program(
 	]
 )
 
-qtEnv = env.Clone()
-qtEnv.Tool('qt')
-
-loudnessValidatorLibraries = [
-	loudnessAnalyserLibStatic,
-	loudnessToolsLibStatic,
-	"sndfile",
-]
-
-loudnessValidatorFrameworks = []
-
-QtLibs = [
-	"QtCore",
-	"QtGui",
-]
-
-if not env['PLATFORM'] == "darwin":
-	loudnessValidatorLibraries.append( QtLibs )
-else:
-	loudnessValidatorFrameworks.append( QtLibs )
-
-loudnessValidatorProgram = qtEnv.Program(
-	'loudness-validator',
-	Glob( 'LoudnessValidator/*.cpp' ),
-	LIBS = loudnessValidatorLibraries,
-	FRAMEWORKS = loudnessValidatorFrameworks,
-)
-
 env.Alias( 'install', env.Install( 'bin', loudnessAnalyserProgram ) )
 env.Alias( 'install', env.Install( 'bin', loudnessCorrectorProgram ) )
-env.Alias( 'install', env.Install( 'bin', loudnessValidatorProgram ) )
+
+# check qt4 library
+conf = Configure(env)
+if conf.CheckLib('QtCore', language='cxx'):
+    env = conf.Finish()
+
+    qtEnv = env.Clone()
+    qtEnv.Tool('qt')
+
+    loudnessValidatorLibraries = [
+        loudnessAnalyserLibStatic,
+        loudnessToolsLibStatic,
+        "sndfile",
+    ]
+
+    loudnessValidatorFrameworks = []
+
+    QtLibs = [
+        "QtCore",
+        "QtGui",
+    ]
+
+    if not qtEnv['PLATFORM'] == "darwin":
+        loudnessValidatorLibraries.append( QtLibs )
+    else:
+        loudnessValidatorFrameworks.append( QtLibs )
+
+    loudnessValidatorProgram = qtEnv.Program(
+        'loudness-validator',
+        Glob( 'LoudnessValidator/*.cpp' ),
+        LIBS = loudnessValidatorLibraries,
+        FRAMEWORKS = loudnessValidatorFrameworks,
+    )
+
+    qtEnv.Alias( 'install', qtEnv.Install( 'bin', loudnessValidatorProgram ) )
+
+else:
+    print 'Warning: did not find QtCore library, will not build loudness-validator app.'

--- a/app/SConscript
+++ b/app/SConscript
@@ -1,66 +1,75 @@
 import os
 Import( 'env' )
-
 Import( 'loudnessAnalyserLibStatic' )
-Import( 'loudnessToolsLibStatic' )
+Import( '*' )
 
-loudnessAnalyserProgram = env.Program(
-	'loudness-analyser',
-	Glob( 'analyser/*.cpp' ),
-	LIBS = [
-		loudnessAnalyserLibStatic,
-		loudnessToolsLibStatic,
-		"sndfile",
-	]
-)
+if 'loudnessToolsLibStatic' in locals():
 
-loudnessCorrectorProgram = env.Program(
-	'loudness-corrector',
-	Glob( 'corrector/*.cpp' ),
-	LIBS = [
-		loudnessAnalyserLibStatic,
-		loudnessToolsLibStatic,
-		"sndfile",
-	]
-)
+	### loudness-analyser ###
 
-env.Alias( 'install', env.Install( 'bin', loudnessAnalyserProgram ) )
-env.Alias( 'install', env.Install( 'bin', loudnessCorrectorProgram ) )
+	loudnessAnalyserProgram = env.Program(
+		'loudness-analyser',
+		Glob( 'analyser/*.cpp' ),
+		LIBS = [
+			loudnessAnalyserLibStatic,
+			loudnessToolsLibStatic,
+			"sndfile",
+		]
+	)
 
-# check qt4 library
-conf = Configure(env)
-if conf.CheckLib('QtCore', language='cxx'):
-    env = conf.Finish()
+	### loudness-corrector ###
 
-    qtEnv = env.Clone()
-    qtEnv.Tool('qt')
+	loudnessCorrectorProgram = env.Program(
+		'loudness-corrector',
+		Glob( 'corrector/*.cpp' ),
+		LIBS = [
+			loudnessAnalyserLibStatic,
+			loudnessToolsLibStatic,
+			"sndfile",
+		]
+	)
 
-    loudnessValidatorLibraries = [
-        loudnessAnalyserLibStatic,
-        loudnessToolsLibStatic,
-        "sndfile",
-    ]
+	env.Alias( 'install', env.Install( 'bin', loudnessAnalyserProgram ) )
+	env.Alias( 'install', env.Install( 'bin', loudnessCorrectorProgram ) )
 
-    loudnessValidatorFrameworks = []
+	### loudness-validator ###
 
-    QtLibs = [
-        "QtCore",
-        "QtGui",
-    ]
+	# check qt4 library
+	conf = Configure(env)
+	if conf.CheckLib('QtCore', language='cxx'):
+	    env = conf.Finish()
 
-    if not qtEnv['PLATFORM'] == "darwin":
-        loudnessValidatorLibraries.append( QtLibs )
-    else:
-        loudnessValidatorFrameworks.append( QtLibs )
+	    qtEnv = env.Clone()
+	    qtEnv.Tool('qt')
 
-    loudnessValidatorProgram = qtEnv.Program(
-        'loudness-validator',
-        Glob( 'LoudnessValidator/*.cpp' ),
-        LIBS = loudnessValidatorLibraries,
-        FRAMEWORKS = loudnessValidatorFrameworks,
-    )
+	    loudnessValidatorLibraries = [
+	        loudnessAnalyserLibStatic,
+	        loudnessToolsLibStatic,
+	        "sndfile",
+	    ]
 
-    qtEnv.Alias( 'install', qtEnv.Install( 'bin', loudnessValidatorProgram ) )
+	    loudnessValidatorFrameworks = []
 
+	    QtLibs = [
+	        "QtCore",
+	        "QtGui",
+	    ]
+
+	    if not qtEnv['PLATFORM'] == "darwin":
+	        loudnessValidatorLibraries.append( QtLibs )
+	    else:
+	        loudnessValidatorFrameworks.append( QtLibs )
+
+	    loudnessValidatorProgram = qtEnv.Program(
+	        'loudness-validator',
+	        Glob( 'LoudnessValidator/*.cpp' ),
+	        LIBS = loudnessValidatorLibraries,
+	        FRAMEWORKS = loudnessValidatorFrameworks,
+	    )
+
+	    qtEnv.Alias( 'install', qtEnv.Install( 'bin', loudnessValidatorProgram ) )
+
+	else:
+	    print('Warning: did not find QtCore library, will not build loudness-validator app.')
 else:
-    print 'Warning: did not find QtCore library, will not build loudness-validator app.'
+	print('Warning: loudnessTools has not been built, will not build applications.')

--- a/app/SConscript
+++ b/app/SConscript
@@ -35,11 +35,11 @@ if 'loudnessToolsLibStatic' in locals():
 	### loudness-validator ###
 
 	# check qt4 library
-	conf = Configure(env)
+	qtEnv = env.Clone()
+	conf = Configure(qtEnv)
 	if conf.CheckLib('QtCore', language='cxx'):
-	    env = conf.Finish()
+	    qtEnv = conf.Finish()
 
-	    qtEnv = env.Clone()
 	    qtEnv.Tool('qt')
 
 	    loudnessValidatorLibraries = [

--- a/src/SConscript
+++ b/src/SConscript
@@ -56,6 +56,7 @@ if conf.CheckLibWithHeader(sndfileLib, 'sndfile.h', 'c'):
         loudnessToolsLibName,
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
+            loudnessAnalyserLibStatic,
             sndfileLib,
         ],
     )
@@ -64,6 +65,7 @@ if conf.CheckLibWithHeader(sndfileLib, 'sndfile.h', 'c'):
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
+            loudnessAnalyserLibStatic,
             sndfileLib,
         ],
     )

--- a/src/SConscript
+++ b/src/SConscript
@@ -1,19 +1,13 @@
 Import( 'env' )
 
-# check libsndfile
-conf = Configure(env)
-if not conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
-    print 'Error: did not find sndfile library, exiting.'
-    Exit(1)
-env = conf.Finish()
+### loudness Analyser ###
 
-# check boost accumulators (header only library) 
+# check boost accumulators (header only library)
 conf = Configure(env)
 if not conf.CheckCXXHeader('boost/accumulators/accumulators.hpp'):
     print 'Error: did not find boost accumulators headers, exiting.'
     Exit(1)
 env = conf.Finish()
-
 
 loudnessAnalyserLib = env.SharedLibrary(
     'loudnessAnalyser',
@@ -27,30 +21,41 @@ loudnessAnalyserLibStatic = env.StaticLibrary(
     Glob( 'loudnessAnalyser/utils/*.cpp' ),
 )
 
-loudnessToolsLib = env.SharedLibrary(
-    'loudnessTools',
-    Glob( 'tool/*/*.cpp' ),
-    LIBS = [
-        "sndfile",
-    ],
-)
-
-loudnessToolsLibStatic = env.StaticLibrary(
-    'loudnessTools',
-    Glob( 'tool/*/*.cpp' ),
-    LIBS = [
-        "sndfile",
-    ],
-)
-
+# Install loudnessAnalyser libs
 env.Alias( 'install', env.InstallVersionedLib( 'lib', loudnessAnalyserLib ) )
 env.Alias( 'install', env.Install( 'lib', loudnessAnalyserLibStatic ) )
-
-env.Alias( 'install', env.InstallVersionedLib( 'lib', loudnessToolsLib ) )
-env.Alias( 'install', env.Install( 'lib', loudnessToolsLibStatic ) )
-
+# Install loudnessAnalyser headers
 env.Alias( 'install', env.Install( 'include/loudnessAnalyser', "loudnessAnalyser/LoudnessAnalyser.hpp" ) )
 
 Export( 'loudnessAnalyserLibStatic' )
-Export( 'loudnessToolsLibStatic' )
 
+### loudness Tools ###
+
+# check libsndfile
+conf = Configure(env)
+if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
+    env = conf.Finish()
+
+    loudnessToolsLib = env.SharedLibrary(
+        'loudnessTools',
+        Glob( 'tool/*/*.cpp' ),
+        LIBS = [
+            "sndfile",
+        ],
+    )
+
+    loudnessToolsLibStatic = env.StaticLibrary(
+        'loudnessTools',
+        Glob( 'tool/*/*.cpp' ),
+        LIBS = [
+            "sndfile",
+        ],
+    )
+
+    # Install
+    env.Alias( 'install', env.InstallVersionedLib( 'lib', loudnessToolsLib ) )
+    env.Alias( 'install', env.Install( 'lib', loudnessToolsLibStatic ) )
+
+    Export( 'loudnessToolsLibStatic' )
+else:
+    print 'Warning: sndfile library not found, will not build loudnessTools.'

--- a/src/SConscript
+++ b/src/SConscript
@@ -48,6 +48,10 @@ if env['PLATFORM'] == 'win32':
 if conf.CheckLibWithHeader(sndfileLib, 'sndfile.h', 'c'):
     sndfileEnv = conf.Finish()
 
+    loudnessToolsLibName = 'loudnessTools'
+    # add version number to the name of the shared library if Windows platform
+    if env['PLATFORM'] == 'win32':
+        loudnessToolsLibName += '-' + loudnessAssessmentVersionStr
     loudnessToolsLib = sndfileEnv.SharedLibrary(
         loudnessToolsLibName,
         Glob( 'tool/*/*.cpp' ),

--- a/src/SConscript
+++ b/src/SConscript
@@ -24,6 +24,7 @@ loudnessAnalyserLibStatic = env.StaticLibrary(
 # Install loudnessAnalyser libs
 env.Alias( 'install', env.InstallVersionedLib( 'lib', loudnessAnalyserLib ) )
 env.Alias( 'install', env.Install( 'lib', loudnessAnalyserLibStatic ) )
+
 # Install loudnessAnalyser headers
 env.Alias( 'install', env.Install( 'include/loudnessAnalyser', "loudnessAnalyser/LoudnessAnalyser.hpp" ) )
 
@@ -40,7 +41,7 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
-            "sndfile",
+            'sndfile',
         ],
     )
 
@@ -48,7 +49,7 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
-            "sndfile",
+            'sndfile',
         ],
     )
 
@@ -58,4 +59,4 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
 
     Export( 'loudnessToolsLibStatic' )
 else:
-    print 'Warning: sndfile library not found, will not build loudnessTools.'
+    print('Warning: sndfile library not found, will not build loudnessTools.')

--- a/src/SConscript
+++ b/src/SConscript
@@ -40,14 +40,19 @@ Export( 'loudnessAnalyserLibStatic' )
 # check libsndfile
 sndfileEnv = env.Clone()
 conf = Configure(sndfileEnv)
-if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
+
+sndfileLib = 'sndfile'
+if env['PLATFORM'] == 'win32':
+    sndfileLib = 'lib' + sndfileLib
+
+if conf.CheckLibWithHeader(sndfileLib, 'sndfile.h', 'c'):
     sndfileEnv = conf.Finish()
 
     loudnessToolsLib = sndfileEnv.SharedLibrary(
-        'loudnessTools',
+        loudnessToolsLibName,
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
-            'sndfile',
+            sndfileLib,
         ],
     )
 
@@ -55,7 +60,7 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
-            'sndfile',
+            sndfileLib,
         ],
     )
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -33,11 +33,12 @@ Export( 'loudnessAnalyserLibStatic' )
 ### loudness Tools ###
 
 # check libsndfile
-conf = Configure(env)
+sndfileEnv = env.Clone()
+conf = Configure(sndfileEnv)
 if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
-    env = conf.Finish()
+    sndfileEnv = conf.Finish()
 
-    loudnessToolsLib = env.SharedLibrary(
+    loudnessToolsLib = sndfileEnv.SharedLibrary(
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
@@ -45,7 +46,7 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
         ],
     )
 
-    loudnessToolsLibStatic = env.StaticLibrary(
+    loudnessToolsLibStatic = sndfileEnv.StaticLibrary(
         'loudnessTools',
         Glob( 'tool/*/*.cpp' ),
         LIBS = [
@@ -54,8 +55,8 @@ if conf.CheckLibWithHeader('sndfile', 'sndfile.h', 'c'):
     )
 
     # Install
-    env.Alias( 'install', env.InstallVersionedLib( 'lib', loudnessToolsLib ) )
-    env.Alias( 'install', env.Install( 'lib', loudnessToolsLibStatic ) )
+    sndfileEnv.Alias( 'install', sndfileEnv.InstallVersionedLib( 'lib', loudnessToolsLib ) )
+    sndfileEnv.Alias( 'install', sndfileEnv.Install( 'lib', loudnessToolsLibStatic ) )
 
     Export( 'loudnessToolsLibStatic' )
 else:

--- a/src/SConscript
+++ b/src/SConscript
@@ -1,4 +1,5 @@
 Import( 'env' )
+Import( 'loudnessAssessmentVersionStr' )
 
 ### loudness Analyser ###
 
@@ -9,8 +10,12 @@ if not conf.CheckCXXHeader('boost/accumulators/accumulators.hpp'):
     Exit(1)
 env = conf.Finish()
 
+loudnessAnalyserLibName = 'loudnessAnalyser'
+# add version number to the name of the shared library if Windows platform
+if env['PLATFORM'] == 'win32':
+    loudnessAnalyserLibName += '-' + loudnessAssessmentVersionStr
 loudnessAnalyserLib = env.SharedLibrary(
-    'loudnessAnalyser',
+    loudnessAnalyserLibName,
     Glob( 'loudnessAnalyser/*.cpp' ) +
     Glob( 'loudnessAnalyser/utils/*.cpp' ),
 )

--- a/src/loudnessAnalyser/Filter.cpp
+++ b/src/loudnessAnalyser/Filter.cpp
@@ -10,6 +10,7 @@
 #define WIDTH_DOUBLE_PRINT 20
 #endif
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 
 

--- a/src/loudnessAnalyser/Histogram.cpp
+++ b/src/loudnessAnalyser/Histogram.cpp
@@ -1,7 +1,9 @@
 
 #include "Histogram.hpp"
-#include <cmath>
 #include "common.hpp"
+
+#include <cmath>
+#include <algorithm>
 
 namespace Loudness
 {

--- a/src/loudnessAnalyser/LoudnessAnalyser.cpp
+++ b/src/loudnessAnalyser/LoudnessAnalyser.cpp
@@ -1,7 +1,6 @@
 
 #include "LoudnessAnalyser.hpp"
 #include "Process.hpp"
-#include "common.hpp"
 
 #include <iostream>
 #include <iomanip>

--- a/src/loudnessAnalyser/LoudnessAnalyser.hpp
+++ b/src/loudnessAnalyser/LoudnessAnalyser.hpp
@@ -2,6 +2,8 @@
 #ifndef _LOUDNESS_ANALYSER_LOUDNESS_ANALYSER_HPP_
 #define _LOUDNESS_ANALYSER_LOUDNESS_ANALYSER_HPP_
 
+#include "common.hpp"
+
 #include <cstdlib>
 #include <vector>
 #include <memory>
@@ -12,7 +14,7 @@ namespace Loudness
 
 #define LOUDNESS_NAN std::numeric_limits<float>::quiet_NaN()
 
-enum EStandard
+enum LoudnessExport EStandard
 {
 	eStandardCST_R017 = 0,
 	eStandardEBU_R128,
@@ -20,7 +22,7 @@ enum EStandard
 	eStandardUnknown
 };
 
-struct LoudnessLevels
+struct LoudnessExport LoudnessLevels
 {
 	float programLoudnessLongProgramMaxValue;
 	float programLoudnessLongProgramMinValue;
@@ -187,7 +189,7 @@ enum ELoudnessResult
 
 class Process;
 
-class LoudnessAnalyser
+class LoudnessExport LoudnessAnalyser
 {
 public:
 	LoudnessAnalyser( LoudnessLevels& levels );

--- a/src/loudnessAnalyser/Process.hpp
+++ b/src/loudnessAnalyser/Process.hpp
@@ -12,9 +12,6 @@
 
 namespace Loudness{
 
-#define MAX_CHANNELS 5
-#define FRAGMENT_SIZE 64
-
 struct LoudnessLevels;
 
 class Process

--- a/src/loudnessAnalyser/TruePeakMeter.cpp
+++ b/src/loudnessAnalyser/TruePeakMeter.cpp
@@ -1,11 +1,11 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 #include "TruePeakMeter.hpp"
 #include "common.hpp"
 #include "utils/HardwareDetection.hpp"
 
-#include <cmath>
 #include <algorithm>
-
 #include <emmintrin.h>
 
 namespace Loudness{

--- a/src/loudnessAnalyser/common.hpp
+++ b/src/loudnessAnalyser/common.hpp
@@ -2,6 +2,9 @@
 #ifndef _LOUDNESS_ANALYSER_COMMON_HPP_
 #define _LOUDNESS_ANALYSER_COMMON_HPP_
 
+#define MAX_CHANNELS 5
+#define FRAGMENT_SIZE 64
+
 #include "system.hpp"
 
 #include <iostream>

--- a/src/loudnessAnalyser/common.hpp
+++ b/src/loudnessAnalyser/common.hpp
@@ -4,6 +4,8 @@
 
 #include <iostream>
 
+#define LoudnessExport __declspec(dllexport)
+
 #ifndef PLOUD_NO_COUT
 /**
  * @param[in] ... : all parameters with an operator << defined

--- a/src/loudnessAnalyser/common.hpp
+++ b/src/loudnessAnalyser/common.hpp
@@ -2,9 +2,22 @@
 #ifndef _LOUDNESS_ANALYSER_COMMON_HPP_
 #define _LOUDNESS_ANALYSER_COMMON_HPP_
 
+#include "system.hpp"
+
 #include <iostream>
 
-#define LoudnessExport __declspec(dllexport)
+#if defined( __WINDOWS__ )
+ #define LoudnessExport __declspec( dllexport )
+#elif defined( __GNUC__ )     // Add compiler definition here...
+ #if __GNUC__ - 0 > 3 || ( __GNUC__ - 0 == 3 && __GNUC_MINOR__ - 0 > 2 )
+  #define LoudnessExport __attribute__ ( ( visibility( "default" ) ) )
+ #else
+  #define LoudnessExport
+  #warning "LoudnessExport not set because of a too old gcc version. The plug-in may not compile with the option -fvisible=hidden."
+ #endif
+#else
+ #error "LoudnessExport not defined for this compiler..."
+#endif
 
 #ifndef PLOUD_NO_COUT
 /**

--- a/src/loudnessAnalyser/system.hpp
+++ b/src/loudnessAnalyser/system.hpp
@@ -1,0 +1,49 @@
+#ifndef _LOUDNESS_ANALYSER_SYSTEM_HPP_
+#define _LOUDNESS_ANALYSER_SYSTEM_HPP_
+
+#if defined( linux ) \
+    || defined( __linux ) \
+    || defined( LINUX ) \
+    || defined( _LINUX ) \
+    || defined( __LINUX__ ) \
+
+ #ifndef __LINUX__
+  #define __LINUX__
+ #endif
+
+
+#elif defined( macintosh ) \
+    || defined( Macintosh ) \
+    || defined( __APPLE__ ) \
+    || defined( __MACH__ ) \
+    || defined( MACOS ) \
+    || defined( MACOSX ) \
+    || defined( __MACOS__ ) \
+
+ #ifndef __MACOS__
+  #define __MACOS__
+ #endif
+
+
+#elif defined( WIN32 ) \
+    || defined( _WIN32 ) \
+    || defined( __WIN32__ ) \
+    || defined( WIN64 ) \
+    || defined( _WIN64 ) \
+    || defined( __WIN64__ ) \
+    || defined( __TOS_WIN__ ) \
+    || defined( WINDOWS ) \
+    || defined( _WINDOWS ) \
+    || defined( __WINDOWS__ ) \
+
+ #ifndef __WINDOWS__
+  #define __WINDOWS__
+ #endif
+
+#else
+
+ #warning "Your operating system is not recognized."
+
+#endif
+
+#endif


### PR DESCRIPTION
* Can you check on MacOS @MarcAntoine-Arnaud ?
* Could be nice to add a way to build the project without loudness-validator (which is the only one with qt4 dependency).