### PR TITLE
mediaAnalyser app: fix check of object returned by readNextFrame

### DIFF
--- a/app/mediaAnalyser/AvSoundFile.cpp
+++ b/app/mediaAnalyser/AvSoundFile.cpp
@@ -172,7 +172,7 @@ void AvSoundFile::analyse(Loudness::analyser::LoudnessAnalyser& analyser)
                 static_cast<avtranscoder::AudioFrame*>(_audioReader.at(fileIndex)->readNextFrame());
 
             // empty frame: go to the end of process
-            if(dstFrame->getSize() == 0)
+            if(dstFrame == NULL)
             {
                 emptyFrameDecoded = true;
                 break;


### PR DESCRIPTION
Could return a NULL pointer since avtranscoder 0.9.2.